### PR TITLE
Change buffering mechanism to allow parallelism by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+
+dist: trusty
 language: ruby
+jdk: openjdk8
 
 rvm:
-  - jruby
+  - jruby-19mode
 
 script:
   - bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+
+rvm:
+  - jruby
+
+script:
+  - bundle exec rspec spec
+
+deploy:
+  provider: rubygems
+  api_key:
+    secure: XH0/YaToo890z8rZ4bqpYmzDw4KVzU1DJjVno6kG1z5ji3+yCd8lsHnb+5G096RBqPqFqlZdYxf5RX4Xb5NKufj5Ecn/5MAsTvnvUPVgFLIwGRy7c5HezrBJ3fciC2fGbnIi6QeI9KrGbfPhIQ1uuywwTOqnCd/8jguemejKrAGP32+OnrnHdD5I+bqTViNXbvoV3WVCEsXN7KCjNDgLJYmOzTk/0m79P7VOUD8VJsf2hT6TSnrIRemkg26UsVXzJ7au2QcRSCPsd/uPJ+AGlrhyGx0ua+hyIcRj/31n9cobsin+OsGOlACvC3CPIaE8hM7c99M7Xlp6YcPCS11huoPAXP/HAwBC1zgQOPd5XtUruHfwUcgDnxUmVo2treQ3hqcn6fZW2pEu8nCYh26jgAvTTS68a8VU8hgGcb5rHH5E9Vg6djAihlKrJPh5VYeoo+TkIaVOjFkyP1K1g9Opb5MJU59ECp7uItsFvzehXr1+0d+SUBwdFjMHSPUjyeWgt3yyfOwf2EnctOWnttgmxLLb0aivfuipZcFk+712fitBXAXoksTLl6/UjrYNrE0reVOgRY/xZ507ZGR5HpzjA9xcKQpK/A0Boqi1dCfV654um//wgzJESLkixrhGNh629uHamIdKLle53yn3htR5I5VEldhu3R4qb2wBtcJ0xhY=
+  gem:
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The easiest way to use this plugin is by installing it through rubygems like any
 bin/logstash-plugin install logstash-output-honeycomb_json_batch
 ```
 
+## Compatibility
+
+This plugin requires Logstash 2.4 or greater. Please open an issue if you require support for older versions.
+
 ## Usage
 
 A simple config is:
@@ -33,7 +37,7 @@ output {
 ```
 
 Additional arguments to `honeycomb_json_batch`:
-- `flush_size`: Maximum batch size, defaults to 50
+- `flush_size`: Maximum batch size, defaults to 75
 - `retry_individual`: On failed requests, whether to retry event sends individually, defaults to true
 - `api_host`: Allows you to override the Honeycomb host, defaults to https://api.honeycomb.io
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ bin/logstash-plugin install logstash-output-honeycomb_json_batch
 
 ## Usage
 
-The default batch size is 50, the default flush interval is 5 seconds, and each of those can be overridden via the plugin config.
-
-A simple config to test this might be:
+A simple config is:
 
 ```
 input {
@@ -35,12 +33,7 @@ output {
 ```
 
 Additional arguments to `honeycomb_json_batch`:
-
-Consider these when tuning performance:
-
-- `flush_size`: Default batch size, defaults to 50
-- `idle_flush_time`: Default flush interval in seconds, defaults to 5
-- `pool_max`: Maximum number of requests to be run in parallel, defaults to 10
+- `flush_size`: Maximum batch size, defaults to 50
 - `retry_individual`: On failed requests, whether to retry event sends individually, defaults to true
 - `api_host`: Allows you to override the Honeycomb host, defaults to https://api.honeycomb.io
 

--- a/lib/logstash/outputs/honeycomb_json_batch.rb
+++ b/lib/logstash/outputs/honeycomb_json_batch.rb
@@ -21,7 +21,7 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
 
   config :retry_individual, :validate => :boolean, :default => true
 
-  config :flush_size, :validate => :number, :default => 50
+  config :flush_size, :validate => :number, :default => 75
 
   # The following configuration options are deprecated and do nothing.
   config :idle_flush_time, :validate => :number, :default => 5

--- a/lib/logstash/outputs/honeycomb_json_batch.rb
+++ b/lib/logstash/outputs/honeycomb_json_batch.rb
@@ -99,8 +99,9 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
 
 
     # Create an async request
+    url = "#{@api_host}/1/batch"
     begin
-      request = client.post("#{@api_host}/1/batch", {
+      request = client.post(url, {
         :body => body,
         :headers => request_headers,
         :async => true
@@ -156,7 +157,7 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
         :url => url,
         :method => @http_method,
         :body => body,
-        :headers => headers,
+        :headers => request_headers,
         :message => exception.message,
         :class => exception.class.name,
         :backtrace => exception.backtrace,

--- a/spec/outputs/honeycomb_json_batch_spec.rb
+++ b/spec/outputs/honeycomb_json_batch_spec.rb
@@ -59,19 +59,19 @@ describe LogStash::Outputs::HoneycombJSONBatch do
                           DATASET => [ { "time" => event.timestamp.to_s, "data" => data } ]
                         }))).once.
                         and_call_original
-
     @honeycomb.multi_receive([event])
   end
 
   it "should extract timestamp and samplerate from the data" do
-    with_samplerate = LogStash::Event.new("alpha" => 1.0, "@samplerate" => "17.5")
+    with_samplerate = LogStash::Event.new("alpha" => 1.0, "@samplerate" => "17.5",
+                                          "@timestamp" => "2014-11-17T20:37:17.223Z")
     data = with_samplerate.to_hash()
     data.delete("@timestamp")
     data.delete("@samplerate")
 
     expect(client).to receive(:post).
                         with("#{ api_host }/1/batch", hash_including(:body => LogStash::Json.dump({
-                          DATASET => [ { "time" => event.timestamp.to_s, "data" => data, "samplerate" => 17 } ]
+                          DATASET => [ { "time" => with_samplerate.timestamp.to_s, "data" => data, "samplerate" => 17 } ]
                         }))).once.
                         and_call_original
 


### PR DESCRIPTION
By default, Logstash output plugins are configured to only use one worker.  Previously, this plugin would issue a synchronous POST within `make_request`, meaning that by default it wouldn't take advantage of any available parallelism.

This patch changes that behavior by specifying `concurrency :shared` and removing internal buffering. This configuration means that Logstash can call `multi_receive` concurrently from each pipeline thread. (By default, the number of pipeline threads is the number of available CPU cores). Logstash will batch events before calling `multi_receive`, so additional internal buffering isn't necessary for performance.

With these changes, the plugin requires Logstash 2.4 or greater. In the future, we can add compatibility for earlier versions if needed.

For further details:
https://www.elastic.co/guide/en/logstash/master/_how_to_write_a_logstash_output_plugin.html
https://www.elastic.co/blog/logstash-2-2-0-and-2-1-2-released