### PR TITLE
bump http_client dependency version to play nicer with other plugins

### DIFF
--- a/lib/logstash/outputs/honeycomb_json_batch.rb
+++ b/lib/logstash/outputs/honeycomb_json_batch.rb
@@ -28,7 +28,7 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
 
   config :pool_max, :validate => :number, :default => 10
 
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 
   def register
     @total = 0

--- a/logstash-output-honeycomb_json_batch.gemspec
+++ b/logstash-output-honeycomb_json_batch.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.1", "< 5.0.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.1", "< 6.0.0"
 
   s.add_development_dependency 'logstash-devutils'
 end


### PR DESCRIPTION
The new version of http_poller needed >=5.0.0.
Bump plugin version to reflect the dependency change.