### PR TITLE
Move Travis build off problematic Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 jdk: openjdk8
 
 rvm:
-  - jruby-9.1.9.0
+  - jruby-19mode
 
 script:
   - bundle exec rspec spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 jdk: openjdk8
 
 rvm:
-  - jruby-19mode
+  - jruby-9.1.9.0
 
 script:
   - bundle exec rspec spec

--- a/logstash-output-honeycomb_json_batch.gemspec
+++ b/logstash-output-honeycomb_json_batch.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
+  s.add_runtime_dependency "faraday", "= 0.13.1"
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.1", "< 7.0.0"
 


### PR DESCRIPTION
Travis is having issues with JRuby 404s, so try 2.2