### PR TITLE
allow spaces in the dataset name via URL-encoding

### DIFF
--- a/lib/logstash/outputs/honeycomb_json_batch.rb
+++ b/lib/logstash/outputs/honeycomb_json_batch.rb
@@ -39,6 +39,8 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
       @api_host = "http://#{ @api_host }"
     end
     @api_host = @api_host.chomp
+    
+    @dataset = URI::encode(@dataset)
 
     logger.info("Initialized honeycomb_json_batch with settings",
       :api_host => @api_host,

--- a/lib/logstash/outputs/honeycomb_json_batch.rb
+++ b/lib/logstash/outputs/honeycomb_json_batch.rb
@@ -28,7 +28,7 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
 
   config :pool_max, :validate => :number, :default => 10
 
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 
   def register
     @total = 0
@@ -39,7 +39,7 @@ class LogStash::Outputs::HoneycombJSONBatch < LogStash::Outputs::Base
       @api_host = "http://#{ @api_host }"
     end
     @api_host = @api_host.chomp
-    
+
     @dataset = URI::encode(@dataset)
 
     logger.info("Initialized honeycomb_json_batch with settings",

--- a/logstash-output-honeycomb_json_batch.gemspec
+++ b/logstash-output-honeycomb_json_batch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-honeycomb_json_batch'
-  s.version         = '0.4.1'
+  s.version         = '0.4.2'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This output lets you `POST` batches of events to the Honeycomb.io API endpoint"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
If a space exists in the dataset name, it fails to create the HTTP POST necessary to get to our servers. This change URL-encodes the dataset name during initialization.